### PR TITLE
FEATURE CE-365: Export opinionated defaults as outputs

### DIFF
--- a/templates/governance.yaml
+++ b/templates/governance.yaml
@@ -243,6 +243,15 @@ Resources:
         - !Ref VerticeGovernanceIAMRole
 
 Outputs:
+  BillingReportName:
+    Condition: CreateReport
+    Value: !Ref BillingReportName
+  BillingReportS3Prefix:
+    Condition: CreateReport
+    Value: !Ref BillingReportS3Prefix
   VerticeGovernanceRoleArn:
     Condition: CreateRole
     Value: !GetAtt VerticeGovernanceIAMRole.Arn
+  VerticeIAMRoleAccountIDs:
+    Condition: CreateRole
+    Value: !Join [",", !Ref VerticeIAMRoleAccountIDs]


### PR DESCRIPTION
Some default parameter values (such as Vertice AWS account IDs referenced in the IAM policies created) don't usually need to be changed during normal usage, but may still need to be easily referenced by customers for use outside of this template.

Relates to https://github.com/VerticeOne/terraform-aws-vertice-integration/pull/11.