### PR TITLE
FIX CE-399: Enable organizations read-only access in billing mode

### DIFF
--- a/templates/governance.yaml
+++ b/templates/governance.yaml
@@ -190,6 +190,8 @@ Resources:
               - 'ec2:DescribeReservedInstancesOfferings'
               - 'ec2:ModifyReservedInstances'
               - 'ec2:PurchaseReservedInstancesOffering'
+              - 'organizations:Describe*'
+              - 'organizations:List*'
               - 'pricing:*'
               - 'savingsplans:Describe*'
               - 'savingsplans:List*'


### PR DESCRIPTION
Read-only access to AWS Organizations is needed for the template in each mode, including billing.