### PR TITLE
FIX CE-432: Remove unnecessary pricing IAM policy statements

### DIFF
--- a/templates/governance.yaml
+++ b/templates/governance.yaml
@@ -192,7 +192,6 @@ Resources:
               - 'ec2:PurchaseReservedInstancesOffering'
               - 'organizations:Describe*'
               - 'organizations:List*'
-              - 'pricing:*'
               - 'savingsplans:Describe*'
               - 'savingsplans:List*'
             Resource: '*'


### PR DESCRIPTION
The `pricing:*` statement is unnecessarily wide, and it's not strictly needed, so remove it from the policy.

Relates to https://github.com/VerticeOne/terraform-aws-vertice-integration/pull/17.