### PR TITLE
FIX CE-478: Allow S3 bucket access for billing mode

### DIFF
--- a/templates/governance.yaml
+++ b/templates/governance.yaml
@@ -199,6 +199,15 @@ Resources:
               - 'savingsplans:Describe*'
               - 'savingsplans:List*'
             Resource: '*'
+          - Sid: 'VerticeBillingBucketAccess'
+            Effect: 'Allow'
+            Action:
+              - 's3:GetBucketLocation'
+              - 's3:ListBucket'
+              - 's3:GetObject'
+            Resource:
+              - !Sub 'arn:aws:s3:::${BillingBucketName}'
+              - !Sub 'arn:aws:s3:::${BillingBucketName}/*'
       Roles:
         - !Ref VerticeGovernanceIAMRole
 


### PR DESCRIPTION
Add a policy statement equivalent to [the template's Terraform counterpart](https://github.com/VerticeOne/terraform-aws-vertice-integration/blob/ac28c5c9ff93e3343140929f21f52502280d38c6/modules/vertice-governance-role/iam_policies.tf#L15-L34), allowing access to the billing data S3 bucket in `billing`-type accounts.