### PR TITLE
FIX BUG-851: Add explicit CUR dependency on bucket policy

### DIFF
--- a/templates/governance.yaml
+++ b/templates/governance.yaml
@@ -186,6 +186,15 @@ Resources:
   VerticeGovernanceBillingReport:
     Type: 'AWS::CUR::ReportDefinition'
     Condition: CreateReport
+    Metadata:
+      DependsOn:
+        [
+          !If [
+            CreateBucket,
+            !Ref VerticeGovernanceS3BucketPolicy,
+            !Ref AWS::NoValue,
+          ],
+        ]
     Properties:
       ReportName: !Ref BillingReportName
       AdditionalArtifacts: ['ATHENA']


### PR DESCRIPTION
There is a race condition whereby CUR can attempt to be created before the required S3 bucket policy is in place; add an explicit `Metadata.DependsOn` to avoid it.