### PR TITLE
FIX ASH-2094: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.env


### PR DESCRIPTION
Prevent committing local secrets by ignoring `.env`.

Ref: https://vertice.atlassian.net/browse/ASH-2094